### PR TITLE
chore: Update Cargo.toml add repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 edition = "2021"
 description = "Tensor library for AI"
 license = "MIT"
+repository = "https://github.com/szuwgh/wwml"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To make it easier for potential contributors and automated tools to find the repository. More explanation: https://github.com/szabgab/rust-digger/issues/89

The page listing your crates can be found here: https://rust-digger.code-maven.com/users/szuwgh I see some of the crates have this field, some don't.
